### PR TITLE
Prevent crash when value contains only empty spaces

### DIFF
--- a/vtortola.WebSockets/Tools/HeadersHelper.cs
+++ b/vtortola.WebSockets/Tools/HeadersHelper.cs
@@ -138,7 +138,7 @@ namespace vtortola.WebSockets.Tools
             if (length == 0)
                 return;
 
-            while (char.IsWhiteSpace(value[startIndex]) && length > 0)
+            while (length > 0 && char.IsWhiteSpace(value[startIndex]))
             {
                 startIndex++;
                 length--;
@@ -146,7 +146,7 @@ namespace vtortola.WebSockets.Tools
 
             if (length == 0) return;
             var end = startIndex + length - 1;
-            while (char.IsWhiteSpace(value[end]) && length > 0)
+            while (length > 0 && char.IsWhiteSpace(value[end]))
             {
                 end--;
                 length--;


### PR DESCRIPTION
Encountered an issue in web socket client when the head of the http response didn't have a description next to the status code.

Example of bad a response which would cause a crash

HTTP/1.1 101
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
X-Application-Context: application
Upgrade: websocket
Connection: upgrade
Sec-WebSocket-Accept: qGEgH3En71di5rrssAZTmtRTyFk=
Date: Thu, 28 Dec 2017 17:25:32 GMT

Working server

HTTP/1.1 101 Web Socket Protocol Handshake
Connection: Upgrade
Date: Thu, 28 Dec 2017 17:26:36 GMT
Sec-WebSocket-Accept: qGEgH3En71di5rrssAZTmtRTyFk=
Server: Kaazing Gateway
Upgrade: websocket