### PR TITLE
Fix race condition with WebSocketMessageWriteRfc6455Stream.CloseAsync

### DIFF
--- a/vtortola.WebSockets.Rfc6455/Streams/WebSocketMessageWriteRfc6455Stream.cs
+++ b/vtortola.WebSockets.Rfc6455/Streams/WebSocketMessageWriteRfc6455Stream.cs
@@ -100,14 +100,14 @@ namespace vtortola.WebSockets.Rfc6455
             var dataFrame = this._webSocket.Connection.PrepareFrame(this._webSocket.Connection.SendBuffer, this._internalUsedBufferLength, true, this._isHeaderSent, this._messageType, this.ExtensionFlags);
             var sendFrameTask = this._webSocket.Connection.SendFrameAsync(dataFrame, CancellationToken.None);
 
-            sendFrameTask.ContinueWith(
+            var endWriteTask = sendFrameTask.ContinueWith(
                 (sendTask, s) => ((WebSocketConnectionRfc6455)s).EndWriting(),
                 this._webSocket.Connection,
                 CancellationToken.None,
                 TaskContinuationOptions.ExecuteSynchronously,
                 TaskScheduler.Default);
 
-            return sendFrameTask;
+            return endWriteTask;
         }
 
         protected override void Dispose(bool disposing)


### PR DESCRIPTION
When sending large messages, a new send operation may start before the un-awaited continuation call to `WebSocketConnectionRfc6455.EndWriting()` runs, resulting in an incorrect exception about an in-progress send operation.