### PR TITLE
Add custom close code overload to CloseAsync()

### DIFF
--- a/vtortola.WebSockets.Rfc6455/Streams/WebSocketMessageWriteRfc6455Stream.cs
+++ b/vtortola.WebSockets.Rfc6455/Streams/WebSocketMessageWriteRfc6455Stream.cs
@@ -144,7 +144,7 @@ namespace vtortola.WebSockets.Rfc6455
             {
                 this.webSocket.Connection.Log.Warning($"Disposed() is called on non-closed {this.GetType()}. Call {nameof(this.CloseAsync)}() or {nameof(this.WriteAndCloseAsync)}() " +
                     "before disposing stream or connections will randomly break.");
-                this.webSocket.Connection.CloseAsync(WebSocketCloseReasons.ProtocolError).Wait();
+                this.webSocket.Connection.CloseAsync(WebSocketCloseReason.ProtocolError).Wait();
             }
         }
     }

--- a/vtortola.WebSockets.Rfc6455/WebSocketConnectionRfc6455.cs
+++ b/vtortola.WebSockets.Rfc6455/WebSocketConnectionRfc6455.cs
@@ -363,7 +363,7 @@ namespace vtortola.WebSockets.Rfc6455
                     var closeMessageOffset = 0;
                     while (closeMessageOffset < CLOSE_BYTES_TO_READ)
                     {
-                        var read = await this.networkConnection.ReadAsync
+                        var closeBytesRead = await this.networkConnection.ReadAsync
                         (
                             this.closeBuffer.Array, 
                             this.closeBuffer.Offset + closeMessageOffset, 
@@ -371,12 +371,12 @@ namespace vtortola.WebSockets.Rfc6455
                             CancellationToken.None
                         ).ConfigureAwait(false);
                         
-                        if (read == 0)
+                        if (closeBytesRead == 0)
                         {
                             break; // connection closed, no more data
                         }
                         
-                        closeMessageOffset += read;
+                        closeMessageOffset += closeBytesRead;
                     }
                     
                     if (closeMessageOffset >= CLOSE_BYTES_TO_READ)

--- a/vtortola.WebSockets.Rfc6455/WebSocketConnectionRfc6455.cs
+++ b/vtortola.WebSockets.Rfc6455/WebSocketConnectionRfc6455.cs
@@ -359,7 +359,7 @@ namespace vtortola.WebSockets.Rfc6455
                 case WebSocketFrameOption.ConnectionClose:
                     Interlocked.CompareExchange(ref this.closeState, CLOSE_STATE_CLOSED, CLOSE_STATE_OPEN);
                     
-                    const CLOSE_BYTES_TO_READ = 2;
+                    const int CLOSE_BYTES_TO_READ = 2;
                     var closeMessageOffset = 0;
                     while (closeMessageOffset < CLOSE_BYTES_TO_READ)
                     {
@@ -370,10 +370,12 @@ namespace vtortola.WebSockets.Rfc6455
                             CLOSE_BYTES_TO_READ - closeMessageOffset, 
                             CancellationToken.None
                         ).ConfigureAwait(false);
+                        
                         if (read == 0)
                         {
                             break; // connection closed, no more data
                         }
+                        
                         closeMessageOffset += read;
                     }
                     

--- a/vtortola.WebSockets.Rfc6455/WebSocketRfc6455.cs
+++ b/vtortola.WebSockets.Rfc6455/WebSocketRfc6455.cs
@@ -84,6 +84,11 @@ namespace vtortola.WebSockets.Rfc6455
             return this.Connection.CloseAsync(WebSocketCloseReasons.NormalClose);
         }
 
+        public override Task CloseAsync(int closeReason)
+        {
+            return this.Connection.CloseAsync((WebSocketCloseReasons)closeReason);
+        }
+
         public override void Dispose()
         {
             SafeEnd.Dispose(this.Connection, this.log);

--- a/vtortola.WebSockets.Rfc6455/WebSocketRfc6455.cs
+++ b/vtortola.WebSockets.Rfc6455/WebSocketRfc6455.cs
@@ -21,9 +21,7 @@ namespace vtortola.WebSockets.Rfc6455
         public override bool IsConnected => this.Connection.IsConnected;
         public override TimeSpan Latency => this.Connection.Latency;
         public override string SubProtocol { get; }
-        public override Nullable<WebSocketCloseReason> CloseReason => this.Connection.CloseReason == default(WebSocketCloseReason)
-            ? default(Nullable<WebSocketCloseReason>)
-            : this.Connection.CloseReason;
+        public override WebSocketCloseReason? CloseReason => this.Connection.CloseReason;
 
         public WebSocketRfc6455([NotNull] NetworkConnection networkConnection, [NotNull] WebSocketListenerOptions options, [NotNull] WebSocketHttpRequest httpRequest, [NotNull] WebSocketHttpResponse httpResponse, [NotNull] IReadOnlyList<IWebSocketMessageExtensionContext> extensions)
             : base(httpRequest, httpResponse)

--- a/vtortola.WebSockets.Rfc6455/WebSocketRfc6455.cs
+++ b/vtortola.WebSockets.Rfc6455/WebSocketRfc6455.cs
@@ -21,6 +21,9 @@ namespace vtortola.WebSockets.Rfc6455
         public override bool IsConnected => this.Connection.IsConnected;
         public override TimeSpan Latency => this.Connection.Latency;
         public override string SubProtocol { get; }
+        public override Nullable<WebSocketCloseReason> CloseReason => this.Connection.CloseReason == default(WebSocketCloseReason)
+            ? default(Nullable<WebSocketCloseReason>)
+            : this.Connection.CloseReason;
 
         public WebSocketRfc6455([NotNull] NetworkConnection networkConnection, [NotNull] WebSocketListenerOptions options, [NotNull] WebSocketHttpRequest httpRequest, [NotNull] WebSocketHttpResponse httpResponse, [NotNull] IReadOnlyList<IWebSocketMessageExtensionContext> extensions)
             : base(httpRequest, httpResponse)
@@ -81,12 +84,12 @@ namespace vtortola.WebSockets.Rfc6455
 
         public override Task CloseAsync()
         {
-            return this.Connection.CloseAsync(WebSocketCloseReasons.NormalClose);
+            return this.Connection.CloseAsync(WebSocketCloseReason.NormalClose);
         }
 
-        public override Task CloseAsync(int closeReason)
+        public override Task CloseAsync(WebSocketCloseReason closeReason)
         {
-            return this.Connection.CloseAsync((WebSocketCloseReasons)closeReason);
+            return this.Connection.CloseAsync(closeReason);
         }
 
         public override void Dispose()

--- a/vtortola.WebSockets/WebSocket.cs
+++ b/vtortola.WebSockets/WebSocket.cs
@@ -42,7 +42,10 @@ namespace vtortola.WebSockets
         }
 
         public abstract Task SendPingAsync(byte[] data, int offset, int count);
+
         public abstract Task CloseAsync();
+
+        public abstract Task CloseAsync(int closeCode);
 
         public abstract void Dispose();
 

--- a/vtortola.WebSockets/WebSocket.cs
+++ b/vtortola.WebSockets/WebSocket.cs
@@ -20,6 +20,7 @@ namespace vtortola.WebSockets
         public abstract EndPoint LocalEndpoint { get; }
         public abstract TimeSpan Latency { get; }
         public abstract string SubProtocol { get; }
+        public abstract Nullable<WebSocketCloseReason> CloseReason { get; }
 
         protected WebSocket([NotNull] WebSocketHttpRequest request, [NotNull] WebSocketHttpResponse response)
         {
@@ -45,7 +46,7 @@ namespace vtortola.WebSockets
 
         public abstract Task CloseAsync();
 
-        public abstract Task CloseAsync(int closeCode);
+        public abstract Task CloseAsync(WebSocketCloseReason closeCode);
 
         public abstract void Dispose();
 

--- a/vtortola.WebSockets/WebSocket.cs
+++ b/vtortola.WebSockets/WebSocket.cs
@@ -20,7 +20,7 @@ namespace vtortola.WebSockets
         public abstract EndPoint LocalEndpoint { get; }
         public abstract TimeSpan Latency { get; }
         public abstract string SubProtocol { get; }
-        public abstract Nullable<WebSocketCloseReason> CloseReason { get; }
+        public abstract WebSocketCloseReason? CloseReason { get; }
 
         protected WebSocket([NotNull] WebSocketHttpRequest request, [NotNull] WebSocketHttpResponse response)
         {

--- a/vtortola.WebSockets/WebSocketCloseReason.cs
+++ b/vtortola.WebSockets/WebSocketCloseReason.cs
@@ -1,7 +1,6 @@
-﻿
-namespace vtortola.WebSockets.Rfc6455
+namespace vtortola.WebSockets
 {
-    public enum WebSocketCloseReasons : short
+    public enum WebSocketCloseReason : short
     {
         NormalClose = 1000,
         GoingAway = 1001,


### PR DESCRIPTION
Continuing #45 

I see that the buffer section allocated to close data is only 2 bytes- it'd take a bit of work to allow arbitrary additional data to be sent along with the close code, although that'd certainly be ideal in terms of RFC complicance. 

A further issue is that I cannot add a `WebSocketCloseReasons` overload to `WebSocket` since that'd require adding a dependency on the RFC6455 package. 

Custom close codes are a fundamental part of the protocol, so I personally think it might be better to move `WebSocketCloseReasons` to the `vtortola.WebSockets` package so the overload can be more idomatic. It's a little "hacky" to expose only an int overload but it's the simplest way to do so in the current setup.