### PR TITLE
Corrected Exception Handling in Samples

### DIFF
--- a/Samples/EchoServer/Program.cs
+++ b/Samples/EchoServer/Program.cs
@@ -144,6 +144,7 @@ namespace WebSocketListenerTests.Echo
                     catch (Exception readWriteError)
                     {
                         Log.Error("An error occurred while reading/writing echo message.", readWriteError);
+                        break;
                     }
                 }
 

--- a/Samples/MonoEchoServer/Program.cs
+++ b/Samples/MonoEchoServer/Program.cs
@@ -154,6 +154,7 @@ namespace MonoEchoServer
                     catch (Exception readWriteError)
                     {
                         Log.Error("An error occurred while reading/writing echo message.", readWriteError);
+                        break;
                     }
                 }
 


### PR DESCRIPTION
If we look at 12d58e02dd9de4587594c5f1b53537795321a641 you will see that CloseAsync was moved to be outside of the exception handling. This caused an infinite loop of exceptions to be thrown for me. I think we must break out of the while loop when an exception occurs.